### PR TITLE
Drop the 1st measurement as inaccurate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -429,6 +429,16 @@ where
         }
 
         let cal = device::Calibration::new(&mut dev)?;
+
+        // read and ignore the 1st measurement since it is inaccurate 
+        let _ = device::HumidityOut::new(&mut dev)?;
+        let _ = device::TemperatureOut::new(&mut dev)?;
+
+        if self.data_rate == DataRate::OneShot {
+            // trigger new measurement
+            device::CtrlReg2::new(&mut dev)?.modify(&mut dev, |w| w.set_one_shot())?;
+        }
+
         Ok(HTS221::<Comm, E> {
             address: self.address,
             calibration: cal,


### PR DESCRIPTION
I noticed that the very first reading after my board is powered on is inaccurate and differs significantly from next ones:
```
iter#000: Temp = 30.250 deg C; rH = 61.5%  
iter#001: Temp = 25.500 deg C; rH = 61.0%   
iter#002: Temp = 25.500 deg C; rH = 61.0%
```
So my PR is to drop the very first reading at the end of initialization and retrigger new measurement if the output data rate mode is set to 'one shot'.