### PR TITLE
Fix overflow panics

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,13 +108,13 @@ where
         const MIN_HUMIDITY: u16 = 0;
         const MAX_HUMIDITY: u16 = 100;
 
-        let h_range_x2 = (self.calibration.h1_rh_x2 - self.calibration.h0_rh_x2) as i16;
-        let adc_range = self.calibration.h1_t0_out - self.calibration.h0_t0_out;
-        let meas = raw - self.calibration.h0_t0_out;
+        let h_range_x2: u8 = self.calibration.h1_rh_x2 - self.calibration.h0_rh_x2;
+        let adc_range: i16 = self.calibration.h1_t0_out - self.calibration.h0_t0_out;
+        let meas = raw as i32 - self.calibration.h0_t0_out as i32;
 
-        let humidity_x2 = self.calibration.h0_rh_x2 as u16
-            + (meas as i32 * h_range_x2 as i32 / adc_range as i32) as u16;
-        clamp(humidity_x2, MIN_HUMIDITY * 2, MAX_HUMIDITY * 2) as u16
+        let humidity_x2 = (self.calibration.h0_rh_x2 as i32
+            + meas * h_range_x2 as i32 / adc_range as i32) as u16;
+        clamp(humidity_x2, MIN_HUMIDITY * 2, MAX_HUMIDITY * 2)
     }
 
     /// Converts a temperature ADC reading into 1/8 degrees Celsius using the device's calibration.
@@ -125,12 +125,12 @@ where
         const MIN_TEMPERATURE: i16 = -40;
         const MAX_TEMPERATURE: i16 = 120;
 
-        let t_range_x8 = (self.calibration.t1_deg_c_x8 - self.calibration.t0_deg_c_x8) as i16;
-        let adc_range = self.calibration.t1_out - self.calibration.t0_out;
-        let meas = raw - self.calibration.t0_out;
+        let t_range_x8: u16 = self.calibration.t1_deg_c_x8 - self.calibration.t0_deg_c_x8;
+        let adc_range: i16 = self.calibration.t1_out - self.calibration.t0_out;
+        let meas = raw as i32 - self.calibration.t0_out as i32;
 
-        let temperature_x8 = self.calibration.t0_deg_c_x8 as i16
-            + (meas as i32 * t_range_x8 as i32 / adc_range as i32) as i16;
+        let temperature_x8 = (self.calibration.t0_deg_c_x8 as i32
+            + meas * t_range_x8 as i32 / adc_range as i32) as i16;
         clamp(temperature_x8, MIN_TEMPERATURE * 8, MAX_TEMPERATURE * 8)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -429,6 +429,16 @@ where
         }
 
         let cal = device::Calibration::new(&mut dev)?;
+
+        // read and ignore the 1st measurement since it is inaccurate 
+        let _ = device::HumidityOut::new(&mut dev)?;
+        let _ = device::TemperatureOut::new(&mut dev)?;
+
+        if self.data_rate == DataRate::OneShot {
+            // trigger new measurement
+            device::CtrlReg2::new(&mut dev)?.modify(&mut dev, |w| w.set_one_shot())?;
+        }
+
         Ok(HTS221::<Comm, E> {
             address: self.address,
             calibration: cal,


### PR DESCRIPTION
Hi Daniel
I got two panics and this PR fixes them.

1. When I exhaled to the chip I got panic and the following  stack frame:
`#5  0x0800059e in hts221::HTS221<Comm,E>::convert_humidity_x2 (self=0x2000fee8, raw=**-32768**) `
`    at /home/slv/ps_rust/contribute/hts221/src/lib.rs:113`
`    113             let meas = raw - self.calibration.h0_t0_out;` 
The Raw reading is MIN value of i16 (-32768 = 0x8000), so subtracting h0_t0_out made panic on overflow.
With the fix, when I exhale, FW shows 100% after clamping and greater than 100% before clamping as expected by document TN1218.  

2. I used a hair dryer to check FW behavior and another panic: 
`panicked at 'attempt to add with overflow', /home/slv/ps_rust/contribute/hts221/src/lib.rs:115:27`
with the following  stack frame:
`#5  0x080005f2 in hts221::HTS221<Comm,E>::convert_humidity_x2 (self=0x2000fee8, raw=**623**)`
`    at /home/slv/ps_rust/contribute/hts221/src/lib.rs:115`
`    115             let humidity_x2 = self.calibration.h0_rh_x2 as u16`
`                                   + (meas as i32 * h_range_x2 as i32 / adc_range as i32) as u16;`
It happened due to humidity dropped below h0_t0_out and that results to (meas as i32 * h_range_x2 as i32 / adc_range as i32) become negative and led to panic.     
More details:
`(gdb) p self.calibration
$6 = hts221::device::Calibration {h0_rh_x2: 61, h1_rh_x2: 138, t0_deg_c_x8: 166, t1_deg_c_x8: 272, h0_t0_out: 7, h1_t0_out: -12628, t0_out: -4, t1_out: 725}`
`(gdb) info locals
meas = 616
adc_range = -12635
h_range_x2 = 77
`
I also made similar changes to `fn convert_temperature_x8`.
Just for convenience I made explicit typing of local variables.

Thanks, Slava 

   